### PR TITLE
Minor change to allow Native AOT compilation

### DIFF
--- a/Sharpie/Backend/NativeLibraryWrapper.cs
+++ b/Sharpie/Backend/NativeLibraryWrapper.cs
@@ -98,7 +98,7 @@ internal sealed class NativeLibraryWrapper<TFunctions>: INativeSymbolResolver, I
         Debug.Assert(dotNetSystemAdapter != null);
 
         if (string.IsNullOrEmpty(dotNetSystemAdapter.GetDirectoryName(libraryNameOrPath)) &&
-            dotNetSystemAdapter.TryLoadNativeLibrary(libraryNameOrPath, Assembly.GetCallingAssembly(), null,
+            dotNetSystemAdapter.TryLoadNativeLibrary(libraryNameOrPath, Assembly.GetExecutingAssembly(), null,
                 out var libHandle) ||
             dotNetSystemAdapter.TryLoadNativeLibrary(libraryNameOrPath, out libHandle))
         {


### PR DESCRIPTION
I'd really like to be able to take advantage of the Native AOT compilation feature in .NET 8 and up when using Sharpie. Apparently the one blocker is a single use of `Assembly.GetCallingAssembly()` in `NativeLibraryWrapper`.

`GetCallingAssembly()` is kinda weird. It returns the assembly of the method that calls the methods that then calls it. I don't know what dark magic it uses to achieve this, but it isn't supported when using Native AOT. However, the way it's being used in this project (inside a private method which is only called from within the same assembly) it always* returns the same result, which is the Sharpie assembly itself. So this PR replaces that call with `GetExecutingAssembly()` which returns the same result doesn't have the same restrictions when used with Native AOT compilation.

Native AOT seems to work fine after this change.

*Apparently there are edge cases where `GetCallingAssembly()` will return a different result depending on how the compiler does inlining, but this doesn't seem to happen and I doubt it's the expected behavior in this case.