### PR TITLE
Updating to support most recent PDCursesMod

### DIFF
--- a/Sharpie/Backend/PdCursesMod32Backend.cs
+++ b/Sharpie/Backend/PdCursesMod32Backend.cs
@@ -118,7 +118,7 @@ internal class PdCursesMod32Backend: PdCursesBackend
 
     public override int slk_touch() => CursesSymbolResolver.Resolve<PdCursesMod32FunctionMap.slk_touch>()();
 
-    public override int endwin() => CursesSymbolResolver.Resolve<PdCursesMod32FunctionMap.endwin_w32_4302>()();
+    public override int endwin() => CursesSymbolResolver.Resolve<PdCursesMod32FunctionMap.endwin_w32_4400>()();
 
     public override int getmouse(out CursesMouseState state) =>
         CursesSymbolResolver.Resolve<PdCursesMod32FunctionMap.nc_getmouse>()(out state);

--- a/Sharpie/Backend/PdCursesMod32FunctionMap.cs
+++ b/Sharpie/Backend/PdCursesMod32FunctionMap.cs
@@ -37,7 +37,7 @@ namespace Sharpie.Backend;
 internal abstract class PdCursesMod32FunctionMap: BaseCursesFunctionMap
 {
     [UnmanagedFunctionPointer(CallingConvention.Winapi)]
-    public delegate int endwin_w32_4302();
+    public delegate int endwin_w32_4400();
 
     [UnmanagedFunctionPointer(CallingConvention.Winapi)]
     public delegate int getcchar(ref uint @char, [MarshalAs(UnmanagedType.LPWStr)] StringBuilder dest, out uint attrs,


### PR DESCRIPTION
(Sorry to bother you with multiple pull requests. I've had a few queued up and this is my day off, so your getting a few at once.)

This is a simple change to the `endwin_*` native function name in `PdCursesMod32FunctionMap`. This matches the current version of PDCursesMod and the one you are distributing via the `Sharpie-Libs-PdCursesMod` nuget package. 

(See https://github.com/Bill-Gray/PDCursesMod/blob/master/curses.h and commit https://github.com/Bill-Gray/PDCursesMod/commit/78658c94cda46ed8c5e4a4a27dc842aec25dea44 for the source of the change).