### PR TITLE
Fix for mouse input when using PDCursesMod backend

### DIFF
--- a/Sharpie.Tests/BaseCursesBackendTests.cs
+++ b/Sharpie.Tests/BaseCursesBackendTests.cs
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2022-2023, Alexandru Ciobanu
+Copyright (c) 2022-2025, Alexandru Ciobanu, Jordan Hemming
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/Sharpie.Tests/BaseCursesBackendTests.cs
+++ b/Sharpie.Tests/BaseCursesBackendTests.cs
@@ -89,7 +89,7 @@ public class BaseCursesBackendTests
     public void DecodeRawMouseButtonState_ParsesUsingMouseParser()
     {
         _backendMock.Setup(s => s.CursesMouseEventParser)
-                    .Returns(CursesMouseEventParser.Get(2));
+                    .Returns(CursesMouseEventParser.Get(CursesAbiVersion.NCurses6));
 
         _backendMock.Setup(s => s.DecodeRawMouseButtonState(It.IsAny<uint>()))
                     .CallBase();
@@ -104,7 +104,7 @@ public class BaseCursesBackendTests
     public void DecodeRawMouseButtonState_ReturnsDefault_IfNotParsed()
     {
         _backendMock.Setup(s => s.CursesMouseEventParser)
-                    .Returns(CursesMouseEventParser.Get(2));
+                    .Returns(CursesMouseEventParser.Get(CursesAbiVersion.NCurses6));
 
         _backendMock.Setup(s => s.DecodeRawMouseButtonState(It.IsAny<uint>()))
                     .CallBase();
@@ -1139,7 +1139,7 @@ public class BaseCursesBackendTests
     [TestMethod, DataRow(0), DataRow(-1)]
     public void mousemask_IsRelayedToLibrary(int ret)
     {
-        var p = CursesMouseEventParser.Get(2);
+        var p = CursesMouseEventParser.Get(CursesAbiVersion.NCurses6);
         _backendMock.Setup(s => s.CursesMouseEventParser)
                     .Returns(p);
 
@@ -1165,7 +1165,7 @@ public class BaseCursesBackendTests
     public void mousemask_WhenUnix_CallsCursesButNotConsole_IfCursesFails()
     {
         _backendMock.Setup(s => s.CursesMouseEventParser)
-                    .Returns(CursesMouseEventParser.Get(1));
+                    .Returns(CursesMouseEventParser.Get(CursesAbiVersion.NCurses5));
 
         _nativeSymbolResolverMock.MockResolve<BaseCursesFunctionMap.mousemask>()
                                  .Setup(s => s(It.IsAny<uint>(), out It.Ref<uint>.IsAny))
@@ -1183,8 +1183,8 @@ public class BaseCursesBackendTests
         _dotNetSystemAdapterMock.Verify(v => v.OutAndFlush(It.IsAny<string>()), Times.Never);
     }
 
-    [TestMethod, SuppressMessage("ReSharper", "IdentifierTypo"), DataRow(1), DataRow(2)]
-    public void mousemask_WhenUnix_OutsToConsole_WhenReportingPosition(int abi)
+    [TestMethod, SuppressMessage("ReSharper", "IdentifierTypo"), DataRow(CursesAbiVersion.NCurses5), DataRow(CursesAbiVersion.NCurses6)]
+    public void mousemask_WhenUnix_OutsToConsole_WhenReportingPosition(CursesAbiVersion abi)
     {
         _nativeSymbolResolverMock.MockResolve<BaseCursesFunctionMap.mousemask, int>(
             s => s(It.IsAny<uint>(), out It.Ref<uint>.IsAny), 0);
@@ -1199,8 +1199,8 @@ public class BaseCursesBackendTests
         _dotNetSystemAdapterMock.Verify(v => v.OutAndFlush("\x1b[?1003h"), Times.Once);
     }
 
-    [TestMethod, SuppressMessage("ReSharper", "IdentifierTypo"), DataRow(1), DataRow(2)]
-    public void mousemask_WhenUnix_OutsToConsole_WhenAll(int abi)
+    [TestMethod, SuppressMessage("ReSharper", "IdentifierTypo"), DataRow(CursesAbiVersion.NCurses5), DataRow(CursesAbiVersion.NCurses6)]
+    public void mousemask_WhenUnix_OutsToConsole_WhenAll(CursesAbiVersion abi)
     {
         _nativeSymbolResolverMock.MockResolve<BaseCursesFunctionMap.mousemask, int>(
             s => s(It.IsAny<uint>(), out It.Ref<uint>.IsAny), 0);
@@ -1222,7 +1222,7 @@ public class BaseCursesBackendTests
             s => s(It.IsAny<uint>(), out It.Ref<uint>.IsAny), 0);
 
         _backendMock.Setup(s => s.CursesMouseEventParser)
-                    .Returns(CursesMouseEventParser.Get(1));
+                    .Returns(CursesMouseEventParser.Get(CursesAbiVersion.NCurses5));
 
         _backend.mousemask(0, out var _)
                 .ShouldBe(0);

--- a/Sharpie.Tests/CursesMouseEventParserTests.cs
+++ b/Sharpie.Tests/CursesMouseEventParserTests.cs
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2022-2023, Alexandru Ciobanu
+Copyright (c) 2022-2025, Alexandru Ciobanu, Jordan Hemming
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/Sharpie.Tests/NCursesBackendTests.cs
+++ b/Sharpie.Tests/NCursesBackendTests.cs
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2022-2023, Alexandru Ciobanu
+Copyright (c) 2022-2025, Alexandru Ciobanu, Jordan Hemming
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/Sharpie.Tests/NCursesBackendTests.cs
+++ b/Sharpie.Tests/NCursesBackendTests.cs
@@ -394,8 +394,8 @@ public class NCursesBackendTests
                                  .Returns(h);
 
         _backend.CursesMouseEventParser.ShouldBe(m == 2
-            ? CursesMouseEventParser.Get(2)
-            : CursesMouseEventParser.Get(1));
+            ? CursesMouseEventParser.Get(CursesAbiVersion.NCurses6)
+            : CursesMouseEventParser.Get(CursesAbiVersion.NCurses5));
     }
 
     [TestMethod]

--- a/Sharpie.Tests/PdCursesBackendTests.cs
+++ b/Sharpie.Tests/PdCursesBackendTests.cs
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2022-2023, Alexandru Ciobanu
+Copyright (c) 2022-2025, Alexandru Ciobanu, Jordan Hemming
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/Sharpie.Tests/PdCursesBackendTests.cs
+++ b/Sharpie.Tests/PdCursesBackendTests.cs
@@ -310,9 +310,9 @@ public class PdCursesBackendTests
     }
 
     [TestMethod]
-    public void CursesMouseEventParser_ReturnsMouseParserAbi2()
+    public void CursesMouseEventParser_ReturnsMouseParserPdCursesAbi()
     {
-        _backend.CursesMouseEventParser.ShouldBe(CursesMouseEventParser.Get(2));
+        _backend.CursesMouseEventParser.ShouldBe(CursesMouseEventParser.Get(CursesAbiVersion.PdCurses));
     }
 
     [TestMethod, DataRow(VideoAttribute.None, 0), DataRow(VideoAttribute.StandOut, 0x00A00000),

--- a/Sharpie.Tests/PdCursesMod32BackendTests.cs
+++ b/Sharpie.Tests/PdCursesMod32BackendTests.cs
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2022-2023, Alexandru Ciobanu
+Copyright (c) 2022-2025, Alexandru Ciobanu, Jordan Hemming
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/Sharpie.Tests/PdCursesMod32BackendTests.cs
+++ b/Sharpie.Tests/PdCursesMod32BackendTests.cs
@@ -373,9 +373,9 @@ public class PdCursesMod32BackendTests
     }
 
     [TestMethod]
-    public void CursesMouseEventParser_ReturnsMouseParserAbi2()
+    public void CursesMouseEventParser_ReturnsMouseParserPdCursesAbi()
     {
-        _backend.CursesMouseEventParser.ShouldBe(CursesMouseEventParser.Get(2));
+        _backend.CursesMouseEventParser.ShouldBe(CursesMouseEventParser.Get(CursesAbiVersion.PdCurses));
     }
 
     [TestMethod, DataRow(VideoAttribute.None, 0), DataRow(VideoAttribute.StandOut, 0x00A00000),

--- a/Sharpie/Backend/CursesAbiVersion.cs
+++ b/Sharpie/Backend/CursesAbiVersion.cs
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2022-2023, Alexandru Ciobanu
+Copyright (c) 2022-2025, Alexandru Ciobanu, Jordan Hemming
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/Sharpie/Backend/CursesAbiVersion.cs
+++ b/Sharpie/Backend/CursesAbiVersion.cs
@@ -1,0 +1,55 @@
+/*
+Copyright (c) 2022-2023, Alexandru Ciobanu
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace Sharpie.Backend;
+
+/// <summary>
+/// Specifies the supported ABI versions for the Curses library.
+/// Used for mouse event parsing.
+/// </summary>
+public enum CursesAbiVersion
+{
+    /// <summary>
+    /// Unknown ABI version. Defaults to NCurses5.
+    /// </summary>
+    Unknown,
+    /// <summary>
+    /// NCurses 5 ABI version.
+    /// </summary>
+    NCurses5,
+    /// <summary>
+    /// NCurses 6 ABI version.
+    /// </summary>
+    NCurses6,
+    /// <summary>
+    /// PDCurses (and PDCursesMod) ABI version.
+    /// </summary>
+    PdCurses
+}

--- a/Sharpie/Backend/CursesMouseEventParser.cs
+++ b/Sharpie/Backend/CursesMouseEventParser.cs
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2022-2023, Alexandru Ciobanu
+Copyright (c) 2022-2025, Alexandru Ciobanu, Jordan Hemming
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/Sharpie/Backend/NCursesBackend.cs
+++ b/Sharpie/Backend/NCursesBackend.cs
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2022-2023, Alexandru Ciobanu
+Copyright (c) 2022-2025, Alexandru Ciobanu, Jordan Hemming
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/Sharpie/Backend/NCursesBackend.cs
+++ b/Sharpie/Backend/NCursesBackend.cs
@@ -59,7 +59,7 @@ internal class NCursesBackend: BaseCursesBackend
             if (_cursesMouseEventParser == null)
             {
                 var ver = curses_version();
-                var abi = -1;
+                var abi = CursesAbiVersion.NCurses5;
                 if (ver != null)
                 {
                     var versionParser = new Regex(@".*(\d+)\.(\d+)\.(\d+)");
@@ -71,8 +71,8 @@ internal class NCursesBackend: BaseCursesBackend
 
                         abi = major switch
                         {
-                            >= 6 => 2,
-                            5 => 1,
+                            >= 6 => CursesAbiVersion.NCurses6,
+                            5 => CursesAbiVersion.NCurses5,
                             var _ => abi
                         };
                     }

--- a/Sharpie/Backend/PdCursesBackend.cs
+++ b/Sharpie/Backend/PdCursesBackend.cs
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2022-2023, Alexandru Ciobanu
+Copyright (c) 2022-2025, Alexandru Ciobanu, Jordan Hemming
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/Sharpie/Backend/PdCursesBackend.cs
+++ b/Sharpie/Backend/PdCursesBackend.cs
@@ -47,7 +47,7 @@ internal class PdCursesBackend: BaseCursesBackend
     internal PdCursesBackend(IDotNetSystemAdapter dotNetSystemAdapter, INativeSymbolResolver pdCursesSymbolResolver,
         INativeSymbolResolver? libCSymbolResolver): base(dotNetSystemAdapter, pdCursesSymbolResolver,
         libCSymbolResolver) =>
-        CursesMouseEventParser = CursesMouseEventParser.Get(2);
+        CursesMouseEventParser = CursesMouseEventParser.Get(CursesAbiVersion.PdCurses);
 
     /// <inheritdoc cref="BaseCursesBackend.CursesMouseEventParser" />
     protected internal override CursesMouseEventParser CursesMouseEventParser { get; }


### PR DESCRIPTION
Mouse movement events weren't working correctly on PDCursesMod. They would only occur when a button was pressed. Also pressing the Control key with a mouse button would report the Alt key being pressed (keyboard events were fine though).

It turns out that PDCurses uses different bits for the mouse event modifiers than either NCurses 5 or 6. PDCursesMod uses this same bitmask. Specifically:
```
Shift = 1<< 26
Control = 1 << 27
Alt = 1 << 28
ReportPosition = 1 << 29
```

These are left shifted by one compared to NCurses 6, with Shift and Control swapped. Since you already have different mouse event parsing for NCurses 5 and 6 I just added another one for PDCurses.

I took the liberty of adding a new overload to `CursesMouseEventParser.Get` which takes an enum rather than an integer as I thought this was more clear with the new addition (the old API is still available, marked as deprecated). If you'd prefer to just stick with the old API I can revert this change.

Tests have been updated as appropriate.

I've tested this with PDCursesMod-WinCon and PDCursesMod-WinGUI on Windows 11 x64, and it fixes mouse movement and the modifier keys.

PDCurses-WinCon still doesn't support the mouse correctly, but I think that's a problem upstream.

I've also tested NCurses 6 on Linux x64 to check that nothing is broken.